### PR TITLE
chore(types): update JSDoc for File type definition

### DIFF
--- a/src/tar.mjs
+++ b/src/tar.mjs
@@ -32,7 +32,7 @@ const DECODER = new TextDecoder();
  * @property {number} uid
  * @property {number} gid
  * @property {Date} lastModified
- * @property {ReadableStream} stream()
+ * @property {() => ReadableStream} stream
  */
 
 const mime = {


### PR DESCRIPTION
Currently, the generated types for `File.stream` are incorrect. The type definition treats `stream` as a property of type `ReadableStream` rather than a function that returns a `ReadableStream`. This PR corrects the type definition.

The change is:

```diff
  export type File = {
      name: string;
      size: number;
      mode: number;
      uname: string;
      gname: string;
      uid: number;
      gid: number;
      lastModified: Date;
-     /**
-      * ()
-      */
-     stream: ReadableStream;
+     stream: () => ReadableStream;
  };
```